### PR TITLE
Add ability to pass a callback to options

### DIFF
--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -167,7 +167,7 @@ class BelongsToManyField extends Field
         }
     }
     
-        /**
+    /**
      * Prepare the field for JSON serialization.
      *
      * @return array
@@ -175,7 +175,7 @@ class BelongsToManyField extends Field
     public function jsonSerialize()
     {
         /**
-         * @var NovaRequest $request
+         * @var NovaRequest
          */
         $request = app(NovaRequest::class);
 

--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -166,7 +166,7 @@ class BelongsToManyField extends Field
             }
         }
     }
-    
+
     /**
      * Prepare the field for JSON serialization.
      *

--- a/src/BelongsToManyField.php
+++ b/src/BelongsToManyField.php
@@ -2,11 +2,11 @@
 
 namespace Everestmx\BelongsToManyField;
 
+use Everestmx\BelongsToManyField\Rules\ArrayRules;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Http\Requests\NovaRequest;
-use Everestmx\BelongsToManyField\Rules\ArrayRules;
 
 /**
  * Class BelongsToManyField
@@ -167,4 +167,42 @@ class BelongsToManyField extends Field
             }
         }
     }
+    
+        /**
+     * Prepare the field for JSON serialization.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+
+        /**
+         * @var NovaRequest $request
+         */
+        $request = app(NovaRequest::class);
+
+        if (isset($this->meta[ 'options' ]) && ($request->isUpdateOrUpdateAttachedRequest() || $request->isCreateOrAttachRequest())) {
+
+            $this->meta[ 'options' ] = $this->meta[ 'options' ]->flatMap(function ($option) {
+
+                if (is_callable($option)) {
+
+                    return call_user_func($option);
+
+                }
+
+                return [ $option ];
+
+            });
+
+        } else {
+
+            $this->meta[ 'options' ] = collect();
+
+        }
+
+        return parent::jsonSerialize();
+
+    }
+
 }


### PR DESCRIPTION
Hi, this PR allows the user to pass a callable to options this avoids the database being hit unnecessarily on details view:

```php
BelongsToManyField::make('Role Label', 'roles', 'App\Nova\Role')
                  ->options(fn() => \App\Role::all())),
```